### PR TITLE
Implement user auth and markdown posts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>annotationProcessor</scope>

--- a/src/main/java/com/project/smartplanai/config/SecurityConfig.java
+++ b/src/main/java/com/project/smartplanai/config/SecurityConfig.java
@@ -1,0 +1,14 @@
+package com.project.smartplanai.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/project/smartplanai/controller/PostController.java
+++ b/src/main/java/com/project/smartplanai/controller/PostController.java
@@ -1,0 +1,57 @@
+package com.project.smartplanai.controller;
+
+import com.project.smartplanai.entity.Post;
+import com.project.smartplanai.entity.User;
+import com.project.smartplanai.service.PostService;
+import com.project.smartplanai.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RestController
+@RequestMapping("/api/posts")
+@RequiredArgsConstructor
+public class PostController {
+    private final PostService postService;
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<Post> create(@RequestBody Map<String, String> body) {
+        String username = body.get("username");
+        Optional<User> userOpt = userService.findByUsername(username);
+        if (userOpt.isEmpty()) {
+            return ResponseEntity.badRequest().build();
+        }
+        Post saved = postService.createPost(userOpt.get(), body.get("title"), body.get("content"));
+        return ResponseEntity.ok(saved);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Post> get(@PathVariable Long id) {
+        return postService.getPost(id).map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<Post>> byUser(@PathVariable Long userId) {
+        return ResponseEntity.ok(postService.getPostsByUser(userId));
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Post> update(@PathVariable Long id, @RequestBody Post post) {
+        if (!postService.getPost(id).isPresent()) {
+            return ResponseEntity.notFound().build();
+        }
+        post.setId(id);
+        return ResponseEntity.ok(postService.updatePost(post));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> delete(@PathVariable Long id) {
+        postService.deletePost(id);
+        return ResponseEntity.ok("deleted");
+    }
+}

--- a/src/main/java/com/project/smartplanai/controller/ScheduleController.java
+++ b/src/main/java/com/project/smartplanai/controller/ScheduleController.java
@@ -30,6 +30,11 @@ public class ScheduleController {
         return ResponseEntity.ok(scheduleService.getAllSchedules());
     }
 
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<Schedule>> getByUser(@PathVariable Long userId) {
+        return ResponseEntity.ok(scheduleService.getSchedulesByUser(userId));
+    }
+
     // 특정 일정 조회 API
     @GetMapping("/{id}")
     public ResponseEntity<Schedule> getScheduleById(@PathVariable Long id) {

--- a/src/main/java/com/project/smartplanai/controller/UserController.java
+++ b/src/main/java/com/project/smartplanai/controller/UserController.java
@@ -1,33 +1,45 @@
 package com.project.smartplanai.controller;
 
 import com.project.smartplanai.entity.User;
+import com.project.smartplanai.enums.Role;
 import com.project.smartplanai.service.UserService;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.Map;
 import java.util.Optional;
 
 @RestController
 @RequestMapping("/api/users")
+@RequiredArgsConstructor
 public class UserController {
-//
-//    private final UserService userService;
-//
-//    public UserController(UserService userService) {
-//        this.userService = userService;
-//    }
-//
-//    @PostMapping("/register")
-//    public ResponseEntity<String> addUser(@RequestBody User user) {
-//        userService.registerUser(user);
-//
-//        return ResponseEntity.ok("회원가입 성공");
-//    }
-//
-//    @GetMapping("{/username}")
-//    public ResponseEntity<User> getUser(@PathVariable String username) {
-//        Optional<User> user = userService.findByUsername(username);
-//        return user.map(ResponseEntity::ok)
-//                .orElseGet(() -> ResponseEntity.notFound().build());
-//    }
+    private final UserService userService;
+
+    @PostMapping("/register")
+    public ResponseEntity<String> register(@RequestBody Map<String, String> body) {
+        String username = body.get("username");
+        String email = body.get("email");
+        String password = body.get("password");
+        if (userService.isUsernameTaken(username) || userService.isEmailTaken(email)) {
+            return ResponseEntity.badRequest().body("duplicate");
+        }
+        userService.registerUser(username, email, password, Role.USER);
+        return ResponseEntity.ok("registered");
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<String> login(@RequestBody Map<String, String> body) {
+        String token = userService.login(body.get("username"), body.get("password"));
+        if (token == null) {
+            return ResponseEntity.status(401).body("invalid");
+        }
+        return ResponseEntity.ok(token);
+    }
+
+    @GetMapping("/{username}")
+    public ResponseEntity<User> getUser(@PathVariable String username) {
+        Optional<User> user = userService.findByUsername(username);
+        return user.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
 }

--- a/src/main/java/com/project/smartplanai/entity/Post.java
+++ b/src/main/java/com/project/smartplanai/entity/Post.java
@@ -1,0 +1,45 @@
+package com.project.smartplanai.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@Table(name = "posts")
+public class Post {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "author_id")
+    private User author;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = this.createdAt;
+    }
+
+    @PreUpdate
+    protected void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/project/smartplanai/repository/PostRepository.java
+++ b/src/main/java/com/project/smartplanai/repository/PostRepository.java
@@ -1,0 +1,10 @@
+package com.project.smartplanai.repository;
+
+import com.project.smartplanai.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+    List<Post> findByAuthorId(Long authorId);
+}

--- a/src/main/java/com/project/smartplanai/repository/UserRepository.java
+++ b/src/main/java/com/project/smartplanai/repository/UserRepository.java
@@ -6,5 +6,7 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
+    boolean existsByUsername(String username);
+    boolean existsByEmail(String email);
 
 }

--- a/src/main/java/com/project/smartplanai/service/PostService.java
+++ b/src/main/java/com/project/smartplanai/service/PostService.java
@@ -1,0 +1,40 @@
+package com.project.smartplanai.service;
+
+import com.project.smartplanai.entity.Post;
+import com.project.smartplanai.entity.User;
+import com.project.smartplanai.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+    private final PostRepository postRepository;
+
+    public Post createPost(User author, String title, String content) {
+        Post post = new Post();
+        post.setTitle(title);
+        post.setContent(content);
+        post.setAuthor(author);
+        return postRepository.save(post);
+    }
+
+    public Optional<Post> getPost(Long id) {
+        return postRepository.findById(id);
+    }
+
+    public List<Post> getPostsByUser(Long userId) {
+        return postRepository.findByAuthorId(userId);
+    }
+
+    public Post updatePost(Post post) {
+        return postRepository.save(post);
+    }
+
+    public void deletePost(Long id) {
+        postRepository.deleteById(id);
+    }
+}

--- a/src/main/java/com/project/smartplanai/service/ScheduleService.java
+++ b/src/main/java/com/project/smartplanai/service/ScheduleService.java
@@ -62,6 +62,10 @@ public class ScheduleService {
         return scheduleRepository.findAll();
     }
 
+    public List<Schedule> getSchedulesByUser(Long userId) {
+        return scheduleRepository.findByAssignedUserId(userId);
+    }
+
     public Optional<Schedule> getScheduleById(Long id){
         return scheduleRepository.findById(id);
     }

--- a/src/main/java/com/project/smartplanai/service/UserService.java
+++ b/src/main/java/com/project/smartplanai/service/UserService.java
@@ -3,7 +3,9 @@ package com.project.smartplanai.service;
 import com.project.smartplanai.entity.User;
 import com.project.smartplanai.enums.Role;
 import com.project.smartplanai.repository.UserRepository;
+import com.project.smartplanai.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -11,41 +13,41 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class UserService {
-/*    private final UserRepository userRepository;
+    private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtUtil jwtUtil;
 
     public User registerUser(String username, String email, String rawPassword, Role role) {
         String encodedPassword = passwordEncoder.encode(rawPassword);
-
         User newUser = User.builder()
                 .username(username)
                 .email(email)
                 .password(encodedPassword)
                 .role(role)
                 .build();
-
         return userRepository.save(newUser);
     }
 
-    // 사용자 ID로 조회
-    public Optional<User> findById(Long id) {
-        return userRepository.findById(id);
-    }
-
-    //사용자 명으로 조회
-    public Optional<User> findUserByUsername(String username) {
+    public Optional<User> findByUsername(String username) {
         return userRepository.findByUsername(username);
     }
 
-    // 이메일 중복 체크
+    public boolean isUsernameTaken(String username) {
+        return userRepository.existsByUsername(username);
+    }
+
     public boolean isEmailTaken(String email) {
         return userRepository.existsByEmail(email);
     }
 
-    // 사용자 로그인 시 비밀번호 확인 (예시)
-    public boolean verifyPassword(String rawPassword, String encodedPassword) {
-        return passwordEncoder.matches(rawPassword, encodedPassword);
-    }*/
+    public String login(String username, String rawPassword) {
+        Optional<User> userOpt = userRepository.findByUsername(username);
+        if (userOpt.isPresent()) {
+            User user = userOpt.get();
+            if (passwordEncoder.matches(rawPassword, user.getPassword())) {
+                return jwtUtil.generateToken(username);
+            }
+        }
+        return null;
+    }
 }
-
-


### PR DESCRIPTION
## Summary
- add Spring Security dependency and password encoder bean
- implement user registration and login with JWT
- add endpoints for schedules by user
- create markdown `Post` entity with CRUD API

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6848416a9480832d9d65b296ef681003